### PR TITLE
Adding `run console` and `run simple` command 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.class
 *.pyc
 *.pyo

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,6 +145,44 @@ works if the vulnerable parameter supports the doc feature (and optionally entit
     >> file:///C:/Users/x/xcat/src/example_application/secret.txt
     This is a secret file. Do not read me!
 
+There are also two other commands `simple` and `console` that will help you navigate larger XML file without having to get everything. They are very 
+useful to have a quick overview of the XML document.
+
+    >> xcat --method=GET --public-ip="localhost" http://localhost:8080 title=Foundation title "1 results found" run simple
+    Injecting using FunctionCall
+    Detecting features...
+    Listening on 0
+    Listening on 42292
+    Supported features: Out of bounds HTTP, String to codepoints, Substring search speedup, Read local XML files, XPath 2, Read local text files
+    Retrieving overview
+    <?xml version="1.0" encoding="utf-8"?>
+    <library>
+	    3 text node
+	    <rentals>
+		    3 text node
+		    <books>
+			    <!--1 comment node-->
+    
+
+For the `console` commands, it will open you a shell where you can type your command and navigate the document.
+
+    Injecting using FunctionCall
+    Detecting features...
+    Listening on 0
+    Listening on 45470
+    Supported features: Substring search speedup, Read local XML files, Read local text files, Out of bounds HTTP, String to codepoints, XPath 2
+    Opening console
+    /*[1] : 
+
+The supported command of the shell are `ls`, `cd`, `attr`, `comment`, `content`, `name`.
+
+    ls - List the name of all the subnode.
+    cd - Change the current node. Use the value `..` to navigate back. to specify an absolute path start with a `/`.
+    attr - List the attributes of the current node.
+    comment - List of the comments node of the current node.
+    content - Return the content of the current node.
+    name - Return the node name of the current node. 
+
 ### Simple usage with the example application
 Check out the [readme](src/example_application) to try out XCat with the provided example application.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -148,6 +148,8 @@ works if the vulnerable parameter supports the doc feature (and optionally entit
 There are also two other commands `simple` and `console` that will help you navigate larger XML file without having to get everything. They are very 
 useful to have a quick overview of the XML document.
 
+The `simple` command :
+
     >> xcat --method=GET --public-ip="localhost" http://localhost:8080 title=Foundation title "1 results found" run simple
     Injecting using FunctionCall
     Detecting features...
@@ -164,7 +166,7 @@ useful to have a quick overview of the XML document.
 			    <!--1 comment node-->
     
 
-For the `console` commands, it will open you a shell where you can type your command and navigate the document.
+The `console` command will open an interactive shell :
 
     Injecting using FunctionCall
     Detecting features...

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,12 +178,12 @@ The `console` command will open an interactive shell :
 
 The supported command of the shell are `ls`, `cd`, `attr`, `comment`, `content`, `name`.
 
-    ls - List the name of all the subnode.
-    cd - Change the current node. Use the value `..` to navigate back. to specify an absolute path start with a `/`.
-    attr - List the attributes of the current node.
-    comment - List of the comments node of the current node.
-    content - Return the content of the current node.
-    name - Return the node name of the current node. 
+ - `ls` - List the name of all the subnode.
+ - `cd` - Change the current node. Use the value `..` to navigate back. to specify an absolute path start with a `/`.
+ - `attr` - List the attributes of the current node.
+ - `comment` - List of the comments node of the current node.
+ - `content` - Return the content of the current node.
+ - `name` - Return the node name of the current node. 
 
 ### Simple usage with the example application
 Check out the [readme](src/example_application) to try out XCat with the provided example application.

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ The `console` command will open an interactive shell :
 The supported command of the shell are `ls`, `cd`, `attr`, `comment`, `content`, `name`.
 
  - `ls` - List the name of all the subnode.
- - `cd` - Change the current node. Use the value `..` to navigate back. to specify an absolute path start with a `/`.
+ - `cd` - Change the current node. Use the value `..` to navigate back. To specify an absolute path start with a `/`.
  - `attr` - List the attributes of the current node.
  - `comment` - List of the comments node of the current node.
  - `content` - Return the content of the current node.

--- a/xcat/lib/executors/xpath1.py
+++ b/xcat/lib/executors/xpath1.py
@@ -16,7 +16,7 @@ class XPath1Executor(BaseExecutor):
             return self.requester.get_feature(EfficientSubstringSearch).execute(self.requester, exp)
         else:
             # Fallback to dumb searching
-            return self.requester.dumb_search(string.ascii_letters + string.digits + " ", exp)
+            return self.requester.dumb_search(string.digits + string.ascii_letters + string.punctuation + " \r\n\t", exp)
 
     @asyncio.coroutine
     def get_string(self, expression):
@@ -26,16 +26,19 @@ class XPath1Executor(BaseExecutor):
         if (yield from self.is_empty_string(expression)):
             return ""
 
-        for i in range(1, string_count + 1):
+        def get_string_task(self, expression, i):
             exp = substring(expression, i, 1)
             char = yield from self.get_char(exp)
 
             if char is None:
-                print("Could not get char at index %s: %s" % (i, substring(expression, i, 1)))
+                print("Could not get char at index %s: %s" % (i, exp))
                 char = "?"
 
-            returner.append(char)
-        return "".join(returner)
+            return char
+        
+        futures = map(asyncio.Task, (get_string_task(self, expression, i) for i in range(1, string_count + 1) ))
+        result = (yield from asyncio.gather(*futures))
+        return "".join(result)
 
     @asyncio.coroutine
     def count_nodes(self, expression):
@@ -56,10 +59,15 @@ class XPath1Executor(BaseExecutor):
     @asyncio.coroutine
     def get_attributes(self, node, count):
         attributes = {}
-        for attribute in node.attributes(count):
+        
+        def get_attributes_task(self, attribute):
             attr_name = yield from self.get_string(attribute.name)
             attr_text = yield from self.get_string(attribute)
-            attributes[attr_name] = attr_text
+            return (attr_name, attr_text)
+
+        futures = map(asyncio.Task, (get_attributes_task(self, attribute) for attribute in node.attributes(count)))
+        results = (yield from asyncio.gather(*futures))
+        attributes = dict(results)
         return attributes
 
     @asyncio.coroutine
@@ -77,26 +85,52 @@ class XPath1Executor(BaseExecutor):
         return comments
 
     @asyncio.coroutine
-    def retrieve_node(self, node):
-        node_name = yield from self.get_string(node.name)
+    def retrieve_node(self, node, simple=False):
+        # Sub-task that run in parallel to retrieve the information of a node.
+        def attributes(self, node):
+            attribute_count = yield from self.count_nodes(node.attributes)
+            attributes_result = yield from self.get_attributes(node, attribute_count)
+            return attributes_result
+        
+        def child_node_count(self, node):
+            child_node_count_result = yield from self.count_nodes(node.children)
+            return child_node_count_result
 
-        attribute_count = yield from self.count_nodes(node.attributes)
-        attributes = yield from self.get_attributes(node, attribute_count)
+        def text(self, node):
+            text_count = yield from self.count_nodes(node.text)
+            text_result = yield from self.get_node_text(node, text_count)
+            return text_result
 
-        child_node_count = yield from self.count_nodes(node.children)
+        def comments(self, node):
+            comment_count = yield from self.count_nodes(node.comments)
+            comments_result = yield from self.get_comments(node, comment_count)
+            return comments_result
 
-        text_count = yield from self.count_nodes(node.text)
-        node_text = yield from self.get_node_text(node, text_count)
+        def node_name(self, node):
+            node_name_result = yield from self.get_string(node.name)
+            return node_name_result
+        
 
-        comment_count = yield from self.count_nodes(node.comments)
-        comments = yield from self.get_comments(node, comment_count)
-
+	    tasks = {
+	        "attributes"       : attributes,
+	        "child_node_count" : child_node_count,
+	        "text"             : text,
+	        "comments"         : comments,
+	        "node_name"        : node_name
+	    }
+        
+        task_list = list(tasks.keys())
+		
+        futures = map(asyncio.Task, (tasks[task_name](self, node) for task_name in task_list ))
+        results = (yield from asyncio.gather(*futures))
+        results = dict(zip(task_list, results))
+        
         return XMLNode(
-            name=node_name,
-            attributes=attributes,
-            comments=comments,
-            text=node_text,
-            child_count=child_node_count,
+            name=results["node_name"],
+            attributes=results["attributes"],
+            comments=results["comments"],
+            text=results["text"],
+            child_count=results["child_node_count"],
             node=node,
             children=[]
         )

--- a/xcat/lib/executors/xpath1.py
+++ b/xcat/lib/executors/xpath1.py
@@ -113,12 +113,7 @@ class XPath1Executor(BaseExecutor):
         @asyncio.coroutine
         def simple_attributes(self, node):
             attribute_count = yield from self.count_nodes(node.attributes)
-            attributes_result = {}
-
-            for i in range(attribute_count):
-                attributes_result["att%i" % i] = "att%i_placeholder" % i
-            
-            return attributes_result
+            return { "att%i" % i : "att%i_placeholder" % i for i in range(attribute_count) }
 
         @asyncio.coroutine
         def simple_text(self, node):

--- a/xcat/lib/features/substring_search.py
+++ b/xcat/lib/features/substring_search.py
@@ -5,7 +5,7 @@ from . import BaseFeature
 from ..xpath import substring_before, string_length
 
 
-SEARCH_SPACE = string.ascii_letters + string.digits + " \n"
+SEARCH_SPACE = string.ascii_letters + string.digits + string.punctuation + " \r\n\t"
 
 
 class EfficientSubstringSearch(BaseFeature):

--- a/xcat/lib/xpath.py
+++ b/xcat/lib/xpath.py
@@ -168,7 +168,16 @@ def arg_to_representation(other):
 
 @arg_to_representation.register(str)
 def _(other):
-    return "'%s'" % other
+    if not "'" in str(other):
+       return "'%s'" % other
+
+    if not '"' in str(other):
+       return '"%s"' % other
+
+    safe_concat = ",".join(arg_to_representation(c) for c in str(other))
+    safe_concat = safe_concat.replace('","', '')
+    safe_concat = safe_concat.replace("','", '')
+    return "concat(" + safe_concat + ")"
 
 @arg_to_representation.register(Expression)
 def _(other):

--- a/xcat/xcat.py
+++ b/xcat/xcat.py
@@ -179,9 +179,11 @@ def console(ctx):
         child_node_count_result = yield from executor.count_nodes(node.children)
         click.echo("%i child node found." % child_node_count_result)
 
-        for child in node.children(child_node_count_result):
-            child_name = yield from executor.get_string(child.name)
-            click.echo(child_name)
+        futures = map(asyncio.Task, (executor.get_string(child.name) for child in node.children(child_node_count_result) ))
+        results = (yield from asyncio.gather(*futures))
+        
+        for result in results:
+            click.echo(result)
 
     @asyncio.coroutine
     def command_cd(node, params):

--- a/xcat/xcat.py
+++ b/xcat/xcat.py
@@ -35,9 +35,11 @@ colorama.init()
 @click.option("--loglevel", type=click.Choice(["debug", "info", "warn", "error"]), default="error")
 @click.option("--logfile", type=click.File("wb", encoding="utf-8"), default="-")
 
+@click.option("--limit", type=click.INT, help="Maximum number of concurrent request sent to the server", default=20)
+
 @click.option("--public-ip", help="Public IP address to use with OOB connections (use 'autodetect' to auto-detect value)")
 @click.pass_context
-def xcat(ctx, target, arguments, target_parameter, match_string, method, detection_method, loglevel, logfile, public_ip):
+def xcat(ctx, target, arguments, target_parameter, match_string, method, detection_method, loglevel, logfile, limit, public_ip):
     null_handler = logbook.NullHandler()
     null_handler.push_application()
 
@@ -70,7 +72,7 @@ def xcat(ctx, target, arguments, target_parameter, match_string, method, detecti
         OOBDocFeature.server = OOBHttpServer(host=public_ip, port=public_port)
 
     ctx.obj["target_param"] = target_parameter
-    request_maker = RequestMaker(target, method, arguments, target_parameter if target_parameter != "*" else None, checker=checker)
+    request_maker = RequestMaker(target, method, arguments, target_parameter if target_parameter != "*" else None, checker=checker, limit_request = limit)
     ctx.obj["detector"] = detector.Detector(checker, request_maker)
 
 
@@ -278,7 +280,6 @@ def display_results(output, executor, target_node, first=True):
         output.output_finished()
 
     return data
-
 
 def run_then_return(generator):
     future = asyncio.Task(generator)


### PR DESCRIPTION
I improved the parallelism of the application so that it can retrieve the content faster on server that have a slow response time, but can take a good amount of load. Since this can create a lot of concurrent request, I have also added an option (--limit) that lets you specify the maximum amount of concurrent request.

The `run console` command let's you navigate inside the XML document with an interactive shell. The `run simple` command works the same way as `run retrieve` except that it queries less information and only output the structure of the document. I have added the documentation of those commands in the `docs/` folder. 

Let me know what you think of it.