### PR TITLE
AttributeError: 'ClientResponse' object has no attribute 'read_and_close'

### DIFF
--- a/xcat/lib/requests/requester.py
+++ b/xcat/lib/requests/requester.py
@@ -76,7 +76,7 @@ class RequestMaker(object):
                url = self.url
 
             response = yield from aiohttp.request(self.method, url,  data=data)
-            body = (yield from response.read_and_close()).decode("utf-8")
+            body = (yield from response.text())
             return response, body
 
     def send_request(self, payload):


### PR DESCRIPTION
There's been a non-forward compatible update in the aiohttp library which requires a small change in the code in order to work now. This commit should the issue.