### PR TITLE
Locking aiohttp to version 1.3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name="xcat",
       author_email="tom@tomforb.es",
       package_dir = {'xcat': 'xcat'},
       packages = ["xcat"] + ["xcat." + p for p in find_packages("xcat")],
-      install_requires=["aiohttp", "click", "logbook", "xmltodict", 'colorama', 'ipgetter'],
+      install_requires=["aiohttp==1.3.5", "click", "logbook", "xmltodict", 'colorama', 'ipgetter'],
       entry_points={
           'console_scripts': [
               'xcat = xcat.xcat:run'


### PR DESCRIPTION
aiohttp's recent upgrade to 2.x.x broke xcat. This restores xcat to a working state without requiring a refactor.