### PR TITLE
Fix aiohttp dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name="xcat",
       author_email="tom@tomforb.es",
       package_dir = {'xcat': 'xcat'},
       packages = ["xcat"] + ["xcat." + p for p in find_packages("xcat")],
-      install_requires=["aiohttp", "click", "logbook", "xmltodict", 'colorama', 'ipgetter'],
+      install_requires=["aiohttp>=1.3.5,<2.0.0", "click", "logbook", "xmltodict", 'colorama', 'ipgetter'],
       entry_points={
           'console_scripts': [
               'xcat = xcat.xcat:run'


### PR DESCRIPTION
xcat does not work with aiohttp 2.x.x. This will ensure a compatible version of aiohttp is installed with xcat.

