### PR TITLE
Add support for tamper scripts

### DIFF
--- a/xcat/attack.py
+++ b/xcat/attack.py
@@ -44,6 +44,7 @@ class AttackContext(NamedTuple):
     headers: Dict[str, str]
     encoding: Encoding
     oob_details: str
+    tamper_function: Callable[[], None]
 
     session: ClientSession = None
     features: Dict[str, bool] = defaultdict(bool)
@@ -107,6 +108,8 @@ async def check(context: AttackContext, payload: str):
         args = {'params': parameters, 'data': context.body}
     else:
         args = {'data': parameters}
+    if context.tamper_function:
+        context.tamper_function(context, args)
 
     async with context.semaphore:
         async with context.session.request(context.method, context.url, **args) as resp:


### PR DESCRIPTION
A tamper function is called just before each request is issued from the `check` function. This is useful if you need to refresh a logged in session every time `check` is called, or maybe if you need to modify arguments to bypass WAF. A tamper function takes two arguments: `context` and `args`, and can modify them in-place.