### PR TITLE
enable use of proxy through env

### DIFF
--- a/xcat/attack.py
+++ b/xcat/attack.py
@@ -64,7 +64,7 @@ class AttackContext(NamedTuple):
 
         semaphore = BoundedSemaphore(self.concurrency)
         connector = TCPConnector(ssl=False, limit=None)
-        async with ClientSession(headers=self.headers, connector=connector) as sesh:
+        async with ClientSession(headers=self.headers, connector=connector, trust_env = True) as sesh:
             yield self._replace(session=sesh, injection=injection, semaphore=semaphore)
 
     @asynccontextmanager


### PR DESCRIPTION
This commit enables use of environment variable HTTP_PROXY.
It would be actually probably much better to implement this properly
using some option (potentially -p?) but just because lack of proxy
support there's this hacky solution.