### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ xpath-expressions = "==1.*,>=1.0.0"
 bumpversion = "^0.6.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
`poetry-core` is intended to be a lightweight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.